### PR TITLE
chore(github-actions): Update GitHub Actions versions in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,12 +28,12 @@ jobs:
       # Create and boot a builder. Used in build-push-action.
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2.5.0
+        uses: docker/setup-buildx-action@v2
 
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v4.4.0
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -51,7 +51,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true


### PR DESCRIPTION
Issue: https://github.com/serlo/backlog/issues/206

---
Some of the actions versions that are used in the in Docker workflow are outdated (e.g. `docker/setup-buildx-action@v2.5.0`), the versions were updated to use the major version tags (e.g. `docker/setup-buildx-action@v2`) as it's done for other actions such as `actions/checkout`. This way the latest minor and patch versions can be used when the workflow runs, and the amount of times that the version needs to be updated in the workflow files is reduced.

