### PR TITLE
feature: Add exercise plugin in content

### DIFF
--- a/src/frontend/plugins/index.tsx
+++ b/src/frontend/plugins/index.tsx
@@ -17,6 +17,7 @@ import { createInputExercisePlugin } from '@/serlo-editor/plugins/input-exercise
 import { createRowsPlugin } from '@/serlo-editor/plugins/rows'
 import { createScMcExercisePlugin } from '@/serlo-editor/plugins/sc-mc-exercise'
 import { createSerloTablePlugin } from '@/serlo-editor/plugins/serlo-table'
+import { exercisePlugin } from '@/serlo-editor/plugins/exercise'
 import { createSpoilerPlugin } from '@/serlo-editor/plugins/spoiler'
 import { createTextPlugin } from '@/serlo-editor/plugins/text'
 import { createEdusharingAssetPlugin } from './edusharing-asset'
@@ -114,25 +115,25 @@ export function createPlugins({ ltik }: { ltik: string }): PluginsWithData {
       icon: <IconTable />,
     },
     {
-      type: EditorPluginType.InputExercise,
+      type: 'exercise',
       plugin: {
-        ...createInputExercisePlugin({}),
-        defaultTitle: 'Aufgabe mit Eingabefeld',
-        defaultDescription:
-          'Interaktive Aufgabe mit Eingabefeld (Text oder Zahlen)',
+        ...exercisePlugin,
+        defaultTitle: 'Aufgabe mit interaktiven Elementen',
+        defaultDescription: '(Interaktive) Aufgabe',
       },
       visibleInSuggestions: true,
       icon: <IconFallback />,
     },
     {
+      type: EditorPluginType.InputExercise,
+      plugin: createInputExercisePlugin({}),
+      visibleInSuggestions: false,
+      icon: <IconFallback />,
+    },
+    {
       type: EditorPluginType.ScMcExercise,
-      plugin: {
-        ...createScMcExercisePlugin(),
-        defaultTitle: 'Multiple-Choice-Aufgabe',
-        defaultDescription:
-          'Interaktive Multiple-Choice-Aufgabe (eine oder mehrere richtige Antworten)',
-      },
-      visibleInSuggestions: true,
+      plugin: createScMcExercisePlugin(),
+      visibleInSuggestions: false,
       icon: <IconFallback />,
     },
 


### PR DESCRIPTION
Todos:

- [ ] Exercise plugin cannot be deleted
- [ ] Exercise plugin needs a config to not show the H5P plugin (we need to discuss whether we want to add this feature with RLP)
- [ ] We need a better design to show which part is the exercise
- [ ] Do we want to support exercises with part solutions as well? (e.g exercise group)