### PR TITLE
fix(edusharing-asset): Make it align to the left

### DIFF
--- a/src/frontend/plugins/edusharing-asset/renderer.tsx
+++ b/src/frontend/plugins/edusharing-asset/renderer.tsx
@@ -54,19 +54,21 @@ export function EdusharingAssetRenderer(props: {
 
   return (
     <figure className="w-full">
-      {embedHtml ? (
-        renderEmbed()
-      ) : (
-        <div className="flex justify-center">
-          <Image
-            className="block opacity-50"
-            src="/edusharing.svg"
-            alt="Edusharing Logo"
-            width="100"
-            height="100"
-          />
-        </div>
-      )}
+      <div className="mx-side">
+        {embedHtml ? (
+          renderEmbed()
+        ) : (
+          <div className="flex justify-center">
+            <Image
+              className="block opacity-50"
+              src="/edusharing.svg"
+              alt="Edusharing Logo"
+              width="100"
+              height="100"
+            />
+          </div>
+        )}
+      </div>
     </figure>
   )
 


### PR DESCRIPTION
Make edusharing embed align left correctly: 
![image](https://github.com/serlo/serlo-editor-for-edusharing/assets/59921805/5c16e1a1-5b6b-42d2-818d-1cdf20f155b5)
