### PR TITLE
fix(edusharing-asset): Video embed (hopefully) using iframe

### DIFF
--- a/src/frontend/plugins/edusharing-asset/renderer.tsx
+++ b/src/frontend/plugins/edusharing-asset/renderer.tsx
@@ -138,7 +138,7 @@ export function EdusharingAssetRenderer(props: {
       const newEmbedHtml = `${detailsSnippet}<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.contentWindow.min.js"></script>`
       return {
         html: newEmbedHtml,
-        renderMethod: 'dangerously-set-inner-html',
+        renderMethod: 'iframe',
       }
     }
 


### PR DESCRIPTION
Before: 
When edu-sharing sends us a html snippet for a video, it does not contain the video itself. Instead, it contains a <script> tag that fetches the video. Using `dangerouslySetInnerHtml` does not execute <script> tags so the video is never fetched. 

Changes: 
If we detect a html snippet containing a video, we instead render the content using an iframe. (here <script> tags are executed)

Review notes: 
- Solution looks very hacky. Making it nice is a topic for later. ^^
- Will the request to fetch the video within the iframe send the same cookies as its host? After a bit of searching I think it does. But I am not 100% sure and I cannot check right now. Anybody know? 
- I try to change as little behavior as possible because RLP is currently testing and we might deploy this while testing is going on. 