### PR TITLE
Use inline instead of embed for edu-sharing snippets

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -298,7 +298,7 @@ const server = (async () => {
         `/${repositoryId}/${nodeId}`,
     )
 
-    url.searchParams.append('displayMode', 'embed')
+    url.searchParams.append('displayMode', 'inline')
     url.searchParams.append('jwt', encodeURIComponent(message))
 
     // HACK: Replace host when in docker, see .env


### PR DESCRIPTION
Hi @kulla ,

I changed the displayMode to "inline", because this is the same mode we use for all other integrations (i.e. moodle, wordpress...) in order to have a more consistent view. The "embed" mode previously used is not recommended for integrations into courses or editors.
