### PR TITLE
feat(edusharing-asset): Render content where no type could be determined in iframe

### DIFF
--- a/src/frontend/plugins/edusharing-asset/renderer.tsx
+++ b/src/frontend/plugins/edusharing-asset/renderer.tsx
@@ -277,10 +277,13 @@ export function EdusharingAssetRenderer(props: {
       }
     }
 
-    // If the detailsSnipped was not handled by one of the handlers above, change nothing in html snippet
+    // Backup when content type could not be determined above -> Render in iframe with iframe-resizer.
+    // This will make sure <script> tags execute. They would not if using 'dangerously-set-inner-html'
     return {
-      html: detailsSnippet,
-      renderMethod: 'dangerously-set-inner-html',
+      html:
+        detailsSnippet +
+        '<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.contentWindow.min.js"></script>',
+      renderMethod: 'iframe',
       defineContainerHeight: false,
     }
   }


### PR DESCRIPTION
Using an iframe as a backup might be safer compared to `dangerouslySetInnerHtml` because <script> tags will get executed.