### PR TITLE
[DO NOT MERGE] fix(edusharing-render): Add serlo-root

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,5 +3,9 @@ import type { AppProps } from 'next/app'
 import '../frontend/styles.css'
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <div id="serlo-root">
+      <Component {...pageProps} />
+    </div>
+  )
 }


### PR DESCRIPTION
depends on https://github.com/serlo/frontend/pull/3554/files 

@hejtful  this fixes the problem you ran into! The consumers of the edusharing package won't render this _app.tsx, I presume. So it's really crucial that you discovered this breaking change in the editor package. Before we merge the web component PR and release a new package of the editor, we'll need to communicate to RLP to add the `serlo-root` id to their root. We can kind of do it ourselves by having a `<div id="serlo-root"> [here](https://github.com/serlo/serlo-editor-for-edusharing/blob/main/src/frontend/serlo-editor.tsx#L33 ), but the higher it is defined in the DOM structure, the better it will be for accessibility when rendering the react-modal.

